### PR TITLE
Add python3 for building requirements

### DIFF
--- a/building/README.md
+++ b/building/README.md
@@ -143,7 +143,8 @@ autoconf \
 texinfo \
 genext2fs \
 libtool \
-libhidapi-dev
+libhidapi-dev \
+python3
 ```
 
 Next, you need to compile the toolchains for all required target architectures:


### PR DESCRIPTION
It's required for NOMMU target to run strip wrapper

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-build/pull/107
https://github.com/phoenix-rtos/phoenix-rtos-ports/pull/39
https://github.com/phoenix-rtos/phoenix-rtos-build/pull/106
https://github.com/phoenix-rtos/phoenix-rtos-doc/pull/114
- [x] I will merge this PR by myself when appropriate.
