### PR TITLE
add wrong code block lexing workaround

### DIFF
--- a/building/index.md
+++ b/building/index.md
@@ -339,7 +339,7 @@ Next, you need to compile the toolchains for all required target architectures:
 cd phoenix-rtos-project
 ```
 
-```console
+```text
 (cd phoenix-rtos-build/toolchain/ && ./build-toolchain.sh i386-pc-phoenix ~/toolchains/i386-pc-phoenix)
 (cd phoenix-rtos-build/toolchain/ && ./build-toolchain.sh arm-phoenix ~/toolchains/arm-phoenix)
 (cd phoenix-rtos-build/toolchain/ && ./build-toolchain.sh riscv64-phoenix ~/toolchains/riscv64-phoenix)

--- a/building/windows.md
+++ b/building/windows.md
@@ -169,7 +169,7 @@ Now, we can follow instructions about building toolchains. Remember to use comma
  cd phoenix-rtos-project
 ```
 
-```console
+```text
 (cd phoenix-rtos-build/toolchain/ && ./build-toolchain.sh i386-pc-phoenix ~/toolchains/i386-pc-phoenix)
 (cd phoenix-rtos-build/toolchain/ && ./build-toolchain.sh arm-phoenix ~/toolchains/arm-phoenix)
 (cd phoenix-rtos-build/toolchain/ && ./build-toolchain.sh riscv64-phoenix ~/toolchains/riscv64-phoenix)


### PR DESCRIPTION
Console lexer incorrectly interpreted code block with running command in subshell as one big generic prompt which made select and copy impossible.

JIRA: CI-508