### PR TITLE
building: Simplify toolchain building command

### DIFF
--- a/building/index.md
+++ b/building/index.md
@@ -345,11 +345,11 @@ cd phoenix-rtos-project
 ```
 
 ```text
-(cd phoenix-rtos-build/toolchain/ && ./build-toolchain.sh i386-pc-phoenix ~/toolchains/i386-pc-phoenix)
-(cd phoenix-rtos-build/toolchain/ && ./build-toolchain.sh arm-phoenix ~/toolchains/arm-phoenix)
-(cd phoenix-rtos-build/toolchain/ && ./build-toolchain.sh riscv64-phoenix ~/toolchains/riscv64-phoenix)
-(cd phoenix-rtos-build/toolchain/ && ./build-toolchain.sh sparc-phoenix ~/toolchains/sparc-phoenix)
-(cd phoenix-rtos-build/toolchain/ && ./build-toolchain.sh aarch64-phoenix ~/toolchains/aarch64-phoenix)
+./phoenix-rtos-build/toolchain/build-toolchain.sh i386-pc-phoenix ~/toolchains/i386-pc-phoenix
+./phoenix-rtos-build/toolchain/build-toolchain.sh arm-phoenix ~/toolchains/arm-phoenix
+./phoenix-rtos-build/toolchain/build-toolchain.sh riscv64-phoenix ~/toolchains/riscv64-phoenix
+./phoenix-rtos-build/toolchain/build-toolchain.sh sparc-phoenix ~/toolchains/sparc-phoenix
+./phoenix-rtos-build/toolchain/build-toolchain.sh aarch64-phoenix ~/toolchains/aarch64-phoenix
 ```
 
 <details>


### PR DESCRIPTION
Simplifying is possible after a31ec05241e22cab646ec9da24490086889226bf in phoenix-rtos-build

I would suggest additional improvement in future:
1. point to `~/toolchains/` dir instead of `~/toolchains/<ARCH>`
Currently directory structure is:
```
toolchains
├── aarch64-phoenix
│   ├── aarch64-phoenix
│   └── _build
├── arm-phoenix
│   ├── arm-phoenix
│   └── _build
├── i386-pc-phoenix
│   ├── _build
│   └── i386-pc-phoenix
├── riscv64-phoenix
│   ├── _build
│   └── riscv64-phoenix
└── sparc-phoenix
    ├── _build
    └── sparc-phoenix
```

```
Better would be:
toolchains
├── aarch64-phoenix
├── arm-phoenix
├── _build
├── i386-pc-phoenix
├── riscv64-phoenix
└── sparc-phoenix
```

It will cause that toolchain binaries would be downloaded once for each toolchain, and directory tree would be simpler

2. Better organize building section 
![image](https://github.com/user-attachments/assets/d6711540-3005-4fc8-9fec-18ce55d6baa6)
It's not easy to spot, that toolchain building instruction is not in Toolchain sub entry, but in Building entry :)
