### PR TITLE
libc: update dirent documentation

### DIFF
--- a/libc/functions/dirent/closedir.part-impl.md
+++ b/libc/functions/dirent/closedir.part-impl.md
@@ -37,7 +37,7 @@ The `closedir()` function may fail if:
 
 ## Tests
 
-Untested
+Tested in [test-libc](https://github.com/phoenix-rtos/phoenix-rtos-tests/tree/master/libc)
 
 ## Known bugs
 

--- a/libc/functions/dirent/opendir.part-impl.md
+++ b/libc/functions/dirent/opendir.part-impl.md
@@ -10,6 +10,14 @@ DIR *fdopendir(int fd);
 DIR *opendir(const char *dirname);
 ```
 
+## Status
+
+Partially implemented
+
+## Conformance
+
+IEEE Std 1003.1-2017
+
 ## Description
 
 The functions open the directory associated with a file descriptor or a name.
@@ -60,3 +68,12 @@ intermediate result with a length that exceeds {`PATH_MAX`}.
 
 * Implement `fdopendir()` function
 * Implement error detection as described above.
+
+## Tests
+
+Tested in [test-libc](https://github.com/phoenix-rtos/phoenix-rtos-tests/tree/master/libc)
+
+## Known bugs
+
+[Issue #1610](https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1610): opendir() exceeds _SC_OPEN_MAX without
+setting EMFILE

--- a/libc/functions/dirent/readdir.part-impl.md
+++ b/libc/functions/dirent/readdir.part-impl.md
@@ -99,8 +99,9 @@ These functions may fail if:
 
 ## Tests
 
-Untested
+Tested in [test-libc](https://github.com/phoenix-rtos/phoenix-rtos-tests/tree/master/libc)
 
 ## Known bugs
 
-None
+[#Issue 1615](https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1615): readdir() silently drops valid
+directory entries of length NAME_MAX

--- a/libc/functions/dirent/rewinddir.part-impl.md
+++ b/libc/functions/dirent/rewinddir.part-impl.md
@@ -1,0 +1,48 @@
+# rewinddir
+
+## Synopsis
+
+```c
+#include <dirent.h>
+
+void rewinddir(DIR *dirp);
+```
+
+## Status
+
+Implemented
+
+## Conformance
+
+IEEE Std 1003.1-2017
+
+## Description
+
+The `rewinddir()` function shall reset the position of a directory stream to the beginning of a directory.
+
+Arguments:
+
+_dirp_ - a pointer to the directory stream to be rewound.
+
+It shall also cause the directory stream to refer to the current state of the corresponding directory, as a
+call to `opendir()` would have done. If _dirp_ does not refer to a directory stream, the effect is undefined.
+
+After a call to the `fork()` function, either the parent or child (but not both) may continue processing the directory
+stream using `readdir()`, `rewinddir()`, or `seekdir()`. If both the parent and child processes use these functions,
+the result is undefined.
+
+## Return value
+
+The `rewinddir()` function shall not return a value.
+
+## Errors
+
+No errors are defined.
+
+## Tests
+
+Tested in [test-libc](https://github.com/phoenix-rtos/phoenix-rtos-tests/tree/master/libc)
+
+## Known bugs
+
+None


### PR DESCRIPTION
JIRA: CI-366

Updating the documentation covering `dirent` functions, following the creation of `dirent` test suite