### PR TITLE
Doc cleanup in build ($PATH commands) and coding (license type)

### DIFF
--- a/building/linux.md
+++ b/building/linux.md
@@ -199,12 +199,12 @@ Then update your `PATH` variable. To make that change persistent across sessions
 shell configuration file (e.g. `~/.bashrc`):
 
 ```shell
-echo 'export PATH=$PATH \
-      :$HOME/toolchains/i386-pc-phoenix/i386-pc-phoenix/bin \
-      :$HOME/toolchains/arm-phoenix/arm-phoenix/bin \
-      :$HOME/toolchains/aarch64-phoenix/aarch64-phoenix/bin \
-      :$HOME/toolchains/riscv64-phoenix/riscv64-phoenix/bin \
-      :$HOME/toolchains/sparc-phoenix/sparc-phoenix/bin' >> $HOME/.bashrc
+echo 'export PATH=$PATH\
+:$HOME/toolchains/i386-pc-phoenix/i386-pc-phoenix/bin\
+:$HOME/toolchains/arm-phoenix/arm-phoenix/bin\
+:$HOME/toolchains/aarch64-phoenix/aarch64-phoenix/bin\
+:$HOME/toolchains/riscv64-phoenix/riscv64-phoenix/bin\
+:$HOME/toolchains/sparc-phoenix/sparc-phoenix/bin' >> $HOME/.bashrc
 ```
 
 As a final step, source the `~/.bashrc` file to apply the changes immediately, or restart your terminal session for

--- a/coding/index.md
+++ b/coding/index.md
@@ -140,8 +140,8 @@ according to the importance of their contribution
 
 The License Identifier specifies the selected license and it can be assigned identifier of one
 of the standard open source license as defined at the [SPDX List](https://spdx.org/licenses/)
-for open source products or `Phoenix-Commercial` for commercial products. The statement
-`SPDX-License-Identifier:` precedes the license identifier.
+for open source products or `LicenseRef-Phoenix-Systems-Commercial` for commercial products.
+The statement `SPDX-License-Identifier:` precedes the license identifier.
 
 For open source products, the default license selected by Phoenix Systems is BSD-3-Clause
 license for which the SPDX defines identifier: `BSD-3-Clause`.


### PR DESCRIPTION
building/linux.md Fix non-working $PATH commands
coding/index.md Fix license reference name

YT: CI-680