### PR TITLE
building: add dtc to build runtime deps

### DIFF
--- a/building/linux.md
+++ b/building/linux.md
@@ -158,7 +158,8 @@ sudo apt-get install -y --no-install-recommends \
   python3-resolvelib \
   python3-pyparsing \
   python3-rich \
-  jq
+  jq \
+  device-tree-compiler
 ```
 
 In the `phoenix-rtos-build/toolchain` directory, run one of the following


### PR DESCRIPTION
YT: CI-690

Necessary for `riscv64` targets