### PR TITLE
doc: unit tests placed next to the code, libsha256

### DIFF
--- a/corelibs/index.md
+++ b/corelibs/index.md
@@ -18,7 +18,8 @@ There are following Phoenix-RTOS libraries:
 - Virtual I/O Device library called `libvirtio`, used for device emulation,
 - Universally Unique identifiers library called `libuuid`,
 - Cache library called `libcache` which provides the user with n-way set-associative cache,
-- Software watchdog library called `libswdg` which provides the user with multichannel software watchdog.
+- Software watchdog library called `libswdg` which provides the user with multichannel software watchdog,
+- SHA-256 library called `libsha256` which provides the user with a message digest without a TLS stack.
 
 ```{toctree}
 :maxdepth: 1
@@ -30,4 +31,5 @@ libgraph.md
 libuuid.md
 libcache.md
 libswdg.md
+libsha256.md
 ```

--- a/corelibs/libsha256.md
+++ b/corelibs/libsha256.md
@@ -1,0 +1,120 @@
+# SHA-256 library (libsha256)
+
+SHA-256 message digest (`FIPS 180-4`) for callers that need a hash without pulling in a TLS stack, for example to verify
+what has been written back to flash or to check a firmware payload before applying it.
+
+The implementation is a single-file extract from [libtomcrypt](https://github.com/libtom/libtomcrypt), kept in the
+upstream formatting so that it stays diffable against the original. The snapshot it was taken from is recorded in
+`libsha256/sbom.json`.
+
+## Application interface
+
+### Data types
+
+- `sha256_ctx_t` - hashing state, allocated by the caller and initialized by `sha256_init`. Its contents are internal
+to the library.
+
+  ```c
+  typedef union {
+      struct sha256_state {
+          uint64_t length;
+          uint32_t state[8], curlen;
+          unsigned char buf[SHA256_BLOCK_SIZE];
+      } sha256;
+  } sha256_ctx_t;
+  ```
+
+### Constants
+
+- `SHA256_DIGEST_SIZE` - digest length in bytes (32),
+- `SHA256_BLOCK_SIZE` - compression function block length in bytes (64).
+
+### Functions
+
+All functions return `0` on success and a non-zero value on failure (invalid arguments, or a message longer than the
+algorithm allows).
+
+- `sha256_init` - Initializes the hashing state `md`. Has to be called before any other operation on it.
+
+  ```c
+  int sha256_init(sha256_ctx_t *md);
+  ```
+
+- `sha256_process` - Processes `inlen` bytes of `in` through the hash. The API is streaming, so it can be called any
+number of times and the message never has to be held in memory as a whole.
+
+  ```c
+  int sha256_process(sha256_ctx_t *md, const unsigned char *in, unsigned long inlen);
+  ```
+
+- `sha256_done` - Terminates the hash, writing `SHA256_DIGEST_SIZE` bytes of digest to `out`. The state must not be
+used afterward without re-initializing it.
+
+  ```c
+  int sha256_done(sha256_ctx_t *md, unsigned char *out);
+  ```
+
+- `mem_neq` - Compares `len` bytes of `a` and `b` in constant time, returning `0` when they are equal and non-zero when
+they are not. Use it wherever inequality means a wrong key or a forged digest - a plain `memcmp()` leaks the position of
+the first mismatch through its execution time. Test the result against `0` and never against `1`: a `NULL` argument is
+reported with a different non-zero value, so `if (mem_neq(...) == 1)` would accept what it was meant to reject.
+
+  ```c
+  int mem_neq(const void *a, const void *b, size_t len);
+  ```
+
+## Using libsha256
+
+Add the library to the `LIBS` variable in the `Makefile` and include the header:
+
+- Makefile - linking with the `libsha256` library.
+
+  ```make
+  NAME := fwverify
+  LOCAL_SRCS := main.c
+  LIBS := libsha256
+
+  include $(binary.mk)
+  ```
+
+- `main.c` - hashing a file without holding it in memory.
+
+  ```c
+  #include <fcntl.h>
+  #include <stdio.h>
+  #include <unistd.h>
+
+  #include <libsha256.h>
+
+  int main(int argc, char *argv[])
+  {
+      sha256_ctx_t ctx;
+      unsigned char digest[SHA256_DIGEST_SIZE], buf[512];
+      ssize_t n;
+      int fd, i;
+
+      fd = open(argv[1], O_RDONLY);
+      if (fd < 0) {
+          return 1;
+      }
+
+      sha256_init(&ctx);
+      while ((n = read(fd, buf, sizeof(buf))) > 0) {
+          sha256_process(&ctx, buf, n);
+      }
+      close(fd);
+
+      sha256_done(&ctx, digest);
+      for (i = 0; i < SHA256_DIGEST_SIZE; i++) {
+          printf("%02x", digest[i]);
+      }
+      printf("\n");
+
+      return 0;
+  }
+  ```
+
+## Tests
+
+The library is covered by unit tests placed next to it, which are built and run by the build system - see
+[Unit tests placed next to the code](../tests/index.md#unit-tests-placed-next-to-the-code).

--- a/index.md
+++ b/index.md
@@ -120,6 +120,7 @@ The ARINC653 execution environment (APEX) is under development.
     5. [Universally Unique identifiers library (libuuid)](corelibs/libuuid.md)
     6. [Cache library (libcache)](corelibs/libcache.md)
     7. [Software watchdog library (libswdg)](corelibs/libswdg.md)
+    8. [SHA-256 library (libsha256)](corelibs/libsha256.md)
 16. [Ports](ports/index.md)
 17. [Tests and testing process](tests/index.md)
 18. [Coding convention](coding/index.md)

--- a/tests/index.md
+++ b/tests/index.md
@@ -738,3 +738,71 @@ TESTS: 2 PASSED: 1 FAILED: 1 SKIPPED: 0
 
 Our test failed as expected. The failure is reported with a sufficient traceback and some additional information like
 the expected value vs actual.
+
+## Unit tests placed next to the code
+
+The examples above keep the test sources in the `phoenix-rtos-tests` repository and run them through the test runner.
+Libraries and tools can also be covered by unit tests kept in their own repository, next to the code they test. Such
+tests are declared to the build system, which builds them for every target and - where the build host is the target -
+runs them directly, with no emulator and no runner involved.
+
+### Declaring a test
+
+The test itself is written with Unity, exactly as in [Example 2](#example-2-unit-tests-using-c). The binary is declared
+with `test-binary.mk` instead of `binary.mk`:
+
+```make
+NAME := test-libsha256
+LOCAL_SRCS := test_libsha256.c
+DEP_LIBS := libsha256
+LIBS := unity
+
+include $(test-binary.mk)
+```
+
+`test-binary.mk` accepts everything `binary.mk` does. The difference is that the component is registered in
+`TEST_COMPONENTS` instead of `ALL_COMPONENTS` - so adding a test does not change what the repository builds and installs
+by default - and that it takes part in the test goals listed below.
+
+Note that `unity` is linked with `LIBS` rather than `DEP_LIBS`: it is a component of another repository
+(`phoenix-rtos-tests`), while `DEP_LIBS` only resolves components of the same one.
+
+A unit test has to be self-contained: no arguments, no fixtures to prepare, the exit status is the verdict.
+
+### Make goals
+
+Every repository containing such tests gains the following goals:
+
+| goal           | does                                                                  |
+|----------------|-----------------------------------------------------------------------|
+| `test`         | build the test binaries                                               |
+| `test-install` | install them into `PREFIX_ROOTFS`                                     |
+| `test-run`     | run them serially (host targets only), the exit status is the verdict |
+| `test-clean`   | clean them (also a prerequisite of the repository's own `clean`)      |
+
+Each test is a component in its own right, so `<NAME>`, `<NAME>-install`, `<NAME>-clean` and `<NAME>-run` work as well.
+If not all tests of a repository build for every target, the list can be narrowed down with `DEFAULT_TEST_COMPONENTS`;
+`TEST_FILTER` (a make pattern, so `%` is the wildcard) selects a subset for a single invocation.
+
+### Building and running the tests
+
+```shell
+TARGET=host-generic-pc ./phoenix-rtos-build/build.sh core test runtest
+```
+
+`test` builds and installs the tests, `runtest` executes them. On a host target the binaries are run on the spot; on a
+cross target they are placed in the rootfs and executed on the device by the test runner described above.
+
+The repositories taking part are listed in `TEST_DIRS` in `build.project`; a target or a project extends the list with
+`TEST_DIRS+=(...)`.
+
+### Building a single test by hand
+
+`build.sh env` spawns a shell with the whole build environment of `$TARGET` exported (marking the prompt, the way a
+Python virtualenv does), so that single components can be built without going through `build.sh`:
+
+```shell
+TARGET=host-generic-pc ./phoenix-rtos-build/build.sh env
+make -C phoenix-rtos-corelibs test-libsha256-run
+make -C phoenix-rtos-corelibs help          # the components and the goals
+```


### PR DESCRIPTION
## Description

- `tests/index.md` - a new section describing unit tests placed next to the code
  they cover: how to declare one with `test-binary.mk`, the
  `test` / `test-install` / `test-run` goals, narrowing with `TEST_FILTER`, how a
  repository joins in through `TEST_DIRS`, and how a cross-built test reaches the
  device. Placed in the existing testing chapter, next to the test-runner
  description, since the two mechanisms coexist.
- `corelibs/libsha256.md` (+ `corelibs/index.md`, `index.md`) - documents the new
  library: the streaming API, `mem_neq()`, and the provenance of the extract.

## Motivation and Context

The mechanism added in phoenix-rtos/phoenix-rtos-build#290 is meant to be adopted by other
repositories, so it needs a user-facing description outside the makefiles. Local
READMEs stay maintainer-facing (extract provenance and the like), following the
libuuid precedent.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

## How Has This Been Tested?

- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `host-generic-pc` - documentation only, but every
      command the new section shows was run: the `test`, `test-install`,
      `test-run` and `test-clean` goals, `<NAME>-run`, `help`, `TEST_FILTER=`
      and `build.sh env`. The `#unit-tests-placed-next-to-the-code` and
      `#example-2-unit-tests-using-c` anchors resolve.

The remaining LanguageTool hits on `corelibs/libsha256.md` are inside the C code
blocks (`const void *a,` reads as an article, `printf("%02x", ...)` as an
unpaired quote) - false positives from a parser that does not see the fences,
left alone. The prose one it found ("afterwards") is fixed.

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).

Describes phoenix-rtos/phoenix-rtos-build#290 and phoenix-rtos/phoenix-rtos-corelibs#67, so it should land
last. Same branch name (`nalajcie/unit-tests`) in every repository. Merge order:

1. phoenix-rtos/phoenix-rtos-build#290 - the mechanism
2. phoenix-rtos/phoenix-rtos-corelibs#67 - the first tests
3. phoenix-rtos/phoenix-rtos-project#1738 - the wiring
4. this PR - the docs

- [ ] I will merge this PR by myself when appropriate.
